### PR TITLE
Fix post-launch visual audit findings

### DIFF
--- a/app/automation/page.tsx
+++ b/app/automation/page.tsx
@@ -1,28 +1,18 @@
-import { Header } from "@/components/ui/header";
-import { HeroSection } from "@/components/HeroSection";
-import { PricingSection } from "@/components/PricingSection";
-import { FooterSection } from "@/components/FooterSection";
+import { I18nProvider } from "@/components/i18n-provider";
+import { AutomationPortfolioPage } from "@/components/pages/AutomationPortfolioPage";
 import { pageMeta } from "@/lib/page-meta";
 
-// Shares the helper with /ua/automation and /ru/automation so the three locales
-// declare matching hreflang alternates and localized share cards.
 export const metadata = pageMeta(
   "en",
   "automation",
-  "AI Automation & Web Systems | Vlad Kuzmenko",
-  "AI automation, websites and MVPs, chatbots and voice assistants, content systems and lead generation — built for real business growth. Book a call or request a system audit.",
+  "AI Systems & Automation for Business | Vlad Kuzmenko",
+  "Interactive examples of AI systems for lead handling, support, booking, sales and structured handoff to a manager.",
 );
 
-// Lean, honest services & pricing page. Fake-stat / fake-testimonial / fake-SaaS
-// sections were removed; the real lead form (HeroSection + PricingSection both
-// open the n8n-backed form) and Cal.com booking are preserved.
-export default function AutomationPage() {
+export default function Page() {
   return (
-    <main className="min-h-screen bg-background">
-      <Header />
-      <HeroSection />
-      <PricingSection />
-      <FooterSection />
-    </main>
+    <I18nProvider lang="en">
+      <AutomationPortfolioPage />
+    </I18nProvider>
   );
 }

--- a/components/pages/AiSystemsPage.tsx
+++ b/components/pages/AiSystemsPage.tsx
@@ -59,7 +59,8 @@ function WaitlistButton({
           subtle
             ? "w-full h-11 bg-transparent border border-amber-400/30 text-white hover:bg-amber-400/10"
             : "premium-button h-12 px-8 text-base",
-          block && !subtle && "w-full"
+          block && !subtle && "w-full",
+          "whitespace-normal text-center leading-5"
         )}
       >
         <Check className="mr-2 h-5 w-5" />
@@ -184,7 +185,7 @@ export function AiSystemsPage() {
                   viewport={{ once: true }}
                   transition={{ delay: i * 0.05 }}
                   className={cn(
-                    "luxe-card p-7 flex flex-col",
+                    "luxe-card min-w-0 p-7 flex flex-col",
                     recommended && "ring-1 ring-amber-400/30 border-amber-400/40"
                   )}
                 >


### PR DESCRIPTION
Production visual audit after PR #6 captured 288 screenshots across all 114 sitemap URLs (mobile and desktop for every route, plus tablet/laptop for core routes).

Fixes in this PR:
- replace the stale English `/automation` legacy pricing page with the same current AutomationPortfolioPage used by `/ua/automation` and `/ru/automation`; this removes outdated fixed-price cards and aligns the route with the current Growth Systems positioning;
- fix the verified 69px horizontal overflow on `/ua/ai-systems` at 390px by allowing tier cards and waitlist CTA text to shrink/wrap correctly.

Audit findings before fix: 1 horizontal overflow, 4 empty-button flags and 1 loading-overlay flag. The automation flags all came from the stale English legacy page and should disappear with the route replacement.

No production merge until CI/preview verification is green.