### PR TITLE
Homepage refinement, section by section

### DIFF
--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -1,45 +1,24 @@
 "use client";
 
 import { Toaster } from "@/components/ui/toaster";
+import { VoiceflowScript } from "@/components/voiceflow-script";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { motion, AnimatePresence, MotionConfig } from "framer-motion";
 
 function LoadingAnimation() {
   return (
-    <motion.div
-      initial={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
-      transition={{ duration: 0.5 }}
-      className="loading-animation"
-    >
-      <motion.div
-        initial={{ scale: 0.96, opacity: 0 }}
-        animate={{ scale: 1, opacity: 1 }}
-        transition={{ duration: 0.55 }}
-        className="flex flex-col items-center justify-center"
-      >
+    <motion.div initial={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.5 }} className="loading-animation">
+      <motion.div initial={{ scale: 0.96, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} transition={{ duration: 0.55 }} className="flex flex-col items-center justify-center">
         <div className="loading-logo mb-8">
-          <span className="text-4xl font-bold font-serif italic gold-gradient logo-underline">
-            Vlad Kuzmenko
-          </span>
+          <span className="text-4xl font-bold font-serif italic gold-gradient logo-underline">Vlad Kuzmenko</span>
         </div>
-        <div className="sound-wave">
-          {[...Array(5)].map((_, i) => (
-            <div key={i} className="sound-bar" />
-          ))}
-        </div>
+        <div className="sound-wave">{[...Array(5)].map((_, i) => <div key={i} className="sound-bar" />)}</div>
       </motion.div>
     </motion.div>
   );
 }
 
-/**
- * Client shell: keeps the existing intro animation and toaster. There is no
- * cart — the site has no ecommerce flow, and Drop is research, not a shop.
- * Split out of the root layout so the layout can stay a server component and
- * use the Next.js Metadata API for proper SEO.
- */
 export function AppShell({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
 
@@ -49,14 +28,16 @@ export function AppShell({ children }: { children: ReactNode }) {
     return () => clearTimeout(t);
   }, []);
 
-  // Page content is always rendered so it exists in the static HTML (crawlers and
-  // link previews see the real page). The intro animation is a full-screen fixed
-  // overlay on top of it, so the visual experience is unchanged.
   return (
     <MotionConfig reducedMotion="user">
       {children}
       <AnimatePresence>{isLoading && <LoadingAnimation key="loading" />}</AnimatePresence>
-      {!isLoading && <Toaster />}
+      {!isLoading && (
+        <>
+          <VoiceflowScript />
+          <Toaster />
+        </>
+      )}
     </MotionConfig>
   );
 }

--- a/components/home/GrowthSystems.tsx
+++ b/components/home/GrowthSystems.tsx
@@ -8,8 +8,7 @@ import { Button } from "@/components/ui/button";
 import { RequestDialog } from "@/components/ui/request-dialog";
 import { useI18n } from "@/components/i18n-provider";
 import { cn } from "@/lib/utils";
-import { track } from "@/lib/analytics";
-import { langHref } from "@/lib/i18n";
+import { langHref, type Lang } from "@/lib/i18n";
 import {
   DIAGNOSTIC_INTENT,
   ENGINE_INTENT,
@@ -27,217 +26,107 @@ const ENGINE_ICON: Record<EngineKey, LucideIcon> = {
   growth: Repeat,
 };
 
-/**
- * Homepage positioning block: the three growth systems, then a short diagnostic
- * that lets a visitor pick a business situation instead of a technology.
- */
+const STYLE: Record<EngineKey, { border: string; glow: string; icon: string; label: string; button: string; dot: string }> = {
+  traffic: { border: "border-amber-300/20 hover:border-amber-300/35", glow: "bg-amber-300/[.09]", icon: "border-amber-300/20 bg-amber-300/[.08] text-amber-300", label: "text-amber-300/80", button: "border-amber-300/20 bg-amber-300/[.06] text-amber-100 hover:bg-amber-300/[.10]", dot: "bg-amber-300" },
+  conversion: { border: "border-sky-300/20 hover:border-sky-300/35", glow: "bg-sky-300/[.08]", icon: "border-sky-300/20 bg-sky-300/[.07] text-sky-200", label: "text-sky-200/80", button: "border-sky-300/20 bg-sky-300/[.055] text-sky-100 hover:bg-sky-300/[.10]", dot: "bg-sky-300" },
+  growth: { border: "border-violet-300/20 hover:border-violet-300/35", glow: "bg-violet-300/[.08]", icon: "border-violet-300/20 bg-violet-300/[.07] text-violet-200", label: "text-violet-200/80", button: "border-violet-300/20 bg-violet-300/[.055] text-violet-100 hover:bg-violet-300/[.10]", dot: "bg-violet-300" },
+};
+
+const HOME_COPY: Record<Lang, { eyebrow: string; titleA: string; titleB: string; desc: string; choose: string; unsure: string }> = {
+  en: { eyebrow: "FOR BUSINESS", titleA: "Where is growth ", titleB: "being lost right now?", desc: "You do not need to choose AI, a website, content or a CRM first. Start with the business problem. The system and tools come after that.", choose: "Choose the situation closest to yours", unsure: "Not sure which one fits?" },
+  ua: { eyebrow: "ДЛЯ БІЗНЕСУ", titleA: "Де зараз ", titleB: "втрачається ріст?", desc: "Не потрібно спочатку обирати AI, сайт, контент чи CRM. Починаємо з бізнес-проблеми, а систему та інструменти підбираємо вже під неї.", choose: "Оберіть ситуацію, найближчу до вашої", unsure: "Не впевнені, що саме підходить?" },
+  ru: { eyebrow: "ДЛЯ БИЗНЕСА", titleA: "Где сейчас ", titleB: "теряется рост?", desc: "Не нужно сначала выбирать AI, сайт, контент или CRM. Начинаем с бизнес-проблемы, а систему и инструменты подбираем уже под неё.", choose: "Выберите ситуацию, которая ближе к вашей", unsure: "Не уверены, что именно подходит?" },
+};
+
 export function GrowthSystems() {
   const { lang } = useI18n();
   const x = getGrowthCopy(lang);
+  const h = HOME_COPY[lang];
   const base = langHref(lang);
   const page = growthRoute(lang);
   const [picked, setPicked] = useState<number | null>(null);
   const chosen = picked === null ? null : x.diagnostic.paths[picked];
 
   return (
-    <section
-      id="client-systems"
-      className="section-accent relative scroll-mt-24 border-t border-zinc-900 bg-black py-24 md:py-32"
-    >
-      <div className="container mx-auto px-4">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          className="mx-auto mb-14 max-w-3xl text-center"
-        >
-          <span className="eyebrow">{x.home.eyebrow}</span>
-          <h2 className="mt-4 text-4xl font-bold tracking-tight md:text-6xl">
-            {x.home.titleA}
-            <span className="gradient-gold-text">{x.home.titleB}</span>
-          </h2>
-          <p className="mt-5 text-lg leading-8 text-gray-400">{x.home.desc}</p>
+    <section id="growth-systems" className="relative scroll-mt-24 overflow-hidden border-t border-white/[.07] bg-[#030303] py-20 md:py-28">
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-[500px] bg-[radial-gradient(ellipse_at_top,rgba(245,190,52,.08),transparent_60%)]" />
+      <div className="pointer-events-none absolute left-0 top-[42%] h-[420px] w-[420px] rounded-full bg-sky-300/[.035] blur-[130px]" />
+      <div className="pointer-events-none absolute right-0 top-[62%] h-[420px] w-[420px] rounded-full bg-violet-300/[.035] blur-[130px]" />
+
+      <div className="container relative z-10 mx-auto px-4">
+        <motion.div initial={{ opacity: 0, y: 18 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} className="mx-auto mb-12 max-w-4xl text-center">
+          <span className="inline-flex items-center rounded-full border border-amber-300/15 bg-amber-300/[.045] px-3 py-1.5 text-[10px] font-bold uppercase tracking-[.22em] text-amber-200/80">{h.eyebrow}</span>
+          <h2 className="mt-5 text-4xl font-black leading-[1.04] tracking-[-.045em] sm:text-5xl md:text-6xl">{h.titleA}<span className="gradient-gold-text">{h.titleB}</span></h2>
+          <p className="mx-auto mt-6 max-w-3xl text-base leading-7 text-zinc-400 sm:text-lg sm:leading-8">{h.desc}</p>
         </motion.div>
 
-        {/* Three systems, separated by the business problem they solve */}
-        <div className="mx-auto grid max-w-6xl gap-6 lg:grid-cols-3">
+        <div className="mx-auto max-w-6xl space-y-4">
           {ENGINE_ORDER.map((key, i) => {
             const e = x.engines.items[key];
             const Icon = ENGINE_ICON[key];
+            const s = STYLE[key];
             return (
-              <motion.article
-                key={key}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ delay: i * 0.06 }}
-                className="luxe-card flex flex-col p-7 sm:p-8"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-amber-400/10">
-                    <Icon className="h-6 w-6 text-amber-400" />
+              <motion.article key={key} initial={{ opacity: 0, y: 18 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ delay: i * 0.05 }} className={cn("group relative overflow-hidden rounded-[28px] border bg-[#080808] transition duration-300", s.border)}>
+                <div className={cn("pointer-events-none absolute -right-20 -top-24 h-64 w-64 rounded-full blur-[100px]", s.glow)} />
+                <div className="relative grid lg:grid-cols-[1.08fr_.92fr]">
+                  <div className="border-b border-white/[.07] p-6 sm:p-8 lg:border-b-0 lg:border-r lg:p-9">
+                    <div className="flex items-center justify-between gap-4">
+                      <span className={cn("flex h-12 w-12 items-center justify-center rounded-2xl border", s.icon)}><Icon className="h-5 w-5" /></span>
+                      <span className="text-[11px] font-bold tracking-[.2em] text-zinc-700">{String(i + 1).padStart(2, "0")}</span>
+                    </div>
+                    <p className={cn("mt-6 text-[10px] font-bold uppercase tracking-[.2em]", s.label)}>{ENGINE_LABEL[key]}</p>
+                    <h3 className="mt-3 max-w-2xl text-2xl font-black leading-tight tracking-[-.035em] text-white sm:text-3xl">{e.bottleneck}</h3>
+                    <p className="mt-4 max-w-2xl text-sm leading-6 text-zinc-400 sm:text-base sm:leading-7">{e.outcome}</p>
                   </div>
-                  <span className="text-[11px] font-semibold uppercase tracking-[.18em] text-zinc-700">
-                    {String(i + 1).padStart(2, "0")}
-                  </span>
-                </div>
-
-                <h3 className="mt-6 text-2xl font-bold tracking-tight">{ENGINE_LABEL[key]}</h3>
-                <p className="mt-3 text-sm font-medium leading-6 text-amber-200/90">{e.bottleneck}</p>
-                <p className="mt-3 flex-1 text-sm leading-6 text-gray-400">{e.outcome}</p>
-
-                <div className="mt-6 flex flex-wrap gap-2">
-                  {e.chips.map((chip) => (
-                    <span
-                      key={chip}
-                      className="rounded-full border border-white/10 bg-white/[.03] px-3 py-1.5 text-[11px] text-zinc-300"
-                    >
-                      {chip}
-                    </span>
-                  ))}
-                </div>
-
-                <div className="mt-7 flex flex-col gap-3 border-t border-white/[.07] pt-5">
-                  <RequestDialog
-                    intent={ENGINE_INTENT[key]}
-                    title={e.cta}
-                    description={x.engines.dialogDesc}
-                    buttonLabel={`Home — ${ENGINE_LABEL[key]}`}
-                    showBuildType={false}
-                    helpLabel={x.engines.helpLabel}
-                    helpPlaceholder={x.engines.helpPlaceholder}
-                    successTitle={x.engines.successTitle}
-                    successMessage={x.engines.successMessage}
-                    context={{ offer: ENGINE_INTENT[key], source: "home_growth_systems", locale: lang, route: base }}
-                  >
-                    <Button
-                      className="premium-button h-auto min-h-11 w-full px-5 py-2.5 text-sm"
-                      onClick={() => track("engine_select", { engine: key, source: "home" })}
-                    >
-                      {e.cta}
-                      <ArrowRight className="ml-2 h-4 w-4 shrink-0" />
-                    </Button>
-                  </RequestDialog>
-                  <a
-                    href={`${page}#${engineAnchor(key)}`}
-                    className="inline-flex items-center justify-center gap-1 text-sm font-medium text-amber-300 transition-colors hover:text-amber-200"
-                  >
-                    {x.home.details}
-                    <ArrowRight className="h-4 w-4" />
-                  </a>
+                  <div className="flex flex-col justify-between p-6 sm:p-8 lg:p-9">
+                    <div className="flex flex-wrap gap-2">{e.chips.map((chip) => <span key={chip} className="rounded-full border border-white/[.09] bg-white/[.025] px-3 py-1.5 text-[11px] text-zinc-300">{chip}</span>)}</div>
+                    <div className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+                      <RequestDialog intent={ENGINE_INTENT[key]} title={e.cta} description={x.engines.dialogDesc} buttonLabel={`Home — ${ENGINE_LABEL[key]}`} showBuildType={false} helpLabel={x.engines.helpLabel} helpPlaceholder={x.engines.helpPlaceholder} successTitle={x.engines.successTitle} successMessage={x.engines.successMessage} context={{ offer: ENGINE_INTENT[key], source: "home_growth_systems", locale: lang, route: base }}>
+                        <Button className={cn("h-auto min-h-11 w-full border px-5 py-2.5 text-sm font-semibold", s.button)}>{e.cta}<ArrowRight className="ml-2 h-4 w-4 shrink-0" /></Button>
+                      </RequestDialog>
+                      <a href={`${page}#${engineAnchor(key)}`} className="w-full"><Button className="h-auto min-h-11 w-full border border-white/[.10] bg-white/[.025] px-5 py-2.5 text-sm text-zinc-200 hover:bg-white/[.055]">{x.home.details}<ArrowRight className="ml-2 h-4 w-4" /></Button></a>
+                    </div>
+                  </div>
                 </div>
               </motion.article>
             );
           })}
         </div>
 
-        {/* Diagnostic: pick a business situation, not a tool */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          className="mx-auto mt-8 max-w-6xl rounded-[28px] border border-amber-300/15 bg-[radial-gradient(circle_at_18%_0%,rgba(245,190,52,.10),transparent_42%),#080808] p-7 sm:p-10"
-        >
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[.2em] text-amber-300/80">
-                <Compass className="h-3.5 w-3.5" />
-                {x.diagnostic.eyebrow}
-              </p>
-              <h3 className="mt-3 text-2xl font-bold tracking-tight sm:text-3xl">{x.home.diagnosticTitle}</h3>
+        <motion.div initial={{ opacity: 0, y: 18 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} className="mx-auto mt-7 max-w-6xl overflow-hidden rounded-[28px] border border-white/[.09] bg-[#070707]">
+          <div className="border-b border-white/[.07] p-6 sm:p-8">
+            <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+              <div><p className="inline-flex items-center gap-2 text-[10px] font-bold uppercase tracking-[.2em] text-zinc-500"><Compass className="h-3.5 w-3.5 text-amber-300" />{h.unsure}</p><h3 className="mt-3 text-2xl font-black tracking-[-.035em] sm:text-3xl">{h.choose}</h3></div>
+              <p className="max-w-md text-sm leading-6 text-zinc-500">{x.diagnostic.desc}</p>
             </div>
-            <p className="max-w-md text-sm leading-6 text-gray-400">{x.home.diagnosticDesc}</p>
           </div>
 
-          <div className="mt-7 grid gap-3 lg:grid-cols-3">
+          <div className="grid md:grid-cols-3">
             {x.diagnostic.paths.map((path, i) => {
               const active = picked === i;
+              const s = STYLE[path.engine];
               return (
-                <button
-                  key={path.value}
-                  type="button"
-                  onClick={() => setPicked(active ? null : i)}
-                  aria-pressed={active}
-                  className={cn(
-                    "rounded-2xl border p-5 text-left transition duration-300",
-                    active
-                      ? "border-amber-300/45 bg-amber-300/[.07]"
-                      : "border-white/[.08] bg-white/[.018] hover:border-amber-300/25 hover:bg-white/[.03]",
-                  )}
-                >
-                  <p className="text-base font-semibold leading-6 text-white">{path.situation}</p>
-                  <p className="mt-2.5 text-sm leading-6 text-gray-400">{path.detail}</p>
-                  <span
-                    className={cn(
-                      "mt-4 inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[.14em] transition-colors",
-                      active ? "text-amber-200" : "text-zinc-400",
-                    )}
-                  >
-                    {x.diagnostic.startWith} {ENGINE_LABEL[path.engine]}
-                  </span>
+                <button key={path.value} type="button" onClick={() => setPicked(active ? null : i)} aria-pressed={active} className={cn("min-h-[190px] border-b border-white/[.07] p-6 text-left transition md:border-b-0 md:border-r md:last:border-r-0 sm:p-7", active ? "bg-white/[.055]" : "bg-transparent hover:bg-white/[.025]")}>
+                  <div className="flex items-center justify-between gap-3"><span className={cn("text-[10px] font-bold uppercase tracking-[.18em]", s.label)}>{ENGINE_LABEL[path.engine]}</span><span className={cn("h-2 w-2 rounded-full transition", active ? s.dot : "bg-zinc-800")} /></div>
+                  <p className="mt-4 text-base font-bold leading-6 text-zinc-100">{path.situation}</p>
+                  <p className="mt-3 text-sm leading-6 text-zinc-500">{path.detail}</p>
                 </button>
               );
             })}
           </div>
 
           {chosen && (
-            <motion.div
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.25 }}
-              className="mt-5 flex flex-col gap-5 rounded-2xl border border-white/[.09] bg-black/50 p-6 sm:p-7 lg:flex-row lg:items-center lg:justify-between"
-            >
-              <div className="max-w-2xl">
-                <p className="text-[10px] font-bold uppercase tracking-[.2em] text-amber-300/75">
-                  {x.home.recommended}
-                </p>
-                <p className="mt-2 text-xl font-bold tracking-tight">{ENGINE_LABEL[chosen.engine]}</p>
-                <p className="mt-2 text-sm leading-6 text-gray-400">
-                  {x.engines.items[chosen.engine].outcome}
-                </p>
-              </div>
+            <motion.div initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.22 }} className="flex flex-col gap-5 border-t border-white/[.07] bg-white/[.018] p-6 sm:p-8 lg:flex-row lg:items-center lg:justify-between">
+              <div className="max-w-2xl"><p className={cn("text-[10px] font-bold uppercase tracking-[.2em]", STYLE[chosen.engine].label)}>{x.home.recommended}</p><p className="mt-2 text-xl font-black tracking-tight">{ENGINE_LABEL[chosen.engine]}</p><p className="mt-2 text-sm leading-6 text-zinc-400">{x.engines.items[chosen.engine].outcome}</p></div>
               <div className="flex shrink-0 flex-col gap-3 sm:flex-row">
-                <RequestDialog
-                  intent={DIAGNOSTIC_INTENT}
-                  title={x.diagnostic.dialogTitle}
-                  description={x.diagnostic.dialogDesc}
-                  buttonLabel={`Home — Diagnostic (${ENGINE_LABEL[chosen.engine]})`}
-                  showBuildType={false}
-                  helpLabel={x.diagnostic.helpLabel}
-                  helpPlaceholder={x.diagnostic.helpPlaceholder}
-                  successTitle={x.diagnostic.successTitle}
-                  successMessage={x.diagnostic.successMessage}
-                  context={{
-                    offer: ENGINE_INTENT[chosen.engine],
-                    situation: chosen.value,
-                    source: "home_growth_diagnostic",
-                    locale: lang,
-                    route: base,
-                  }}
-                >
-                  <Button className="premium-button h-auto min-h-11 w-full px-6 py-2.5 sm:w-auto">
-                    {x.diagnostic.cta}
-                    <ArrowRight className="ml-2 h-4 w-4" />
-                  </Button>
+                <RequestDialog intent={DIAGNOSTIC_INTENT} title={x.diagnostic.dialogTitle} description={x.diagnostic.dialogDesc} buttonLabel={`Home — Diagnostic (${ENGINE_LABEL[chosen.engine]})`} showBuildType={false} helpLabel={x.diagnostic.helpLabel} helpPlaceholder={x.diagnostic.helpPlaceholder} successTitle={x.diagnostic.successTitle} successMessage={x.diagnostic.successMessage} context={{ offer: ENGINE_INTENT[chosen.engine], situation: chosen.value, source: "home_growth_diagnostic", locale: lang, route: base }}>
+                  <Button className="premium-button h-auto min-h-11 w-full px-6 py-2.5 sm:w-auto">{x.diagnostic.cta}<ArrowRight className="ml-2 h-4 w-4" /></Button>
                 </RequestDialog>
-                <a href={`${page}#${engineAnchor(chosen.engine)}`} className="w-full sm:w-auto">
-                  <Button className="h-auto min-h-11 w-full border border-white/15 bg-white/[.035] px-6 py-2.5 text-white hover:bg-white/[.08] sm:w-auto">
-                    {x.home.details}
-                  </Button>
-                </a>
+                <a href={`${page}#${engineAnchor(chosen.engine)}`} className="w-full sm:w-auto"><Button className="h-auto min-h-11 w-full border border-white/15 bg-white/[.03] px-6 py-2.5 text-white hover:bg-white/[.07] sm:w-auto">{x.home.details}</Button></a>
               </div>
             </motion.div>
           )}
-
-          <div className="mt-7 text-center sm:text-left">
-            <a
-              href={page}
-              className="inline-flex items-center gap-1.5 text-sm font-semibold text-amber-300 transition-colors hover:text-amber-200"
-            >
-              {x.home.seeAll}
-              <ArrowRight className="h-4 w-4" />
-            </a>
-          </div>
+          <div className="border-t border-white/[.07] p-5 text-center"><a href={page} className="inline-flex items-center gap-1.5 text-sm font-semibold text-amber-300 transition-colors hover:text-amber-200">{x.home.seeAll}<ArrowRight className="h-4 w-4" /></a></div>
         </motion.div>
       </div>
     </section>

--- a/components/home/Hero.tsx
+++ b/components/home/Hero.tsx
@@ -1,12 +1,50 @@
 "use client";
 
-import React from "react";
 import { motion } from "framer-motion";
-import { ArrowDown, Calendar } from "lucide-react";
+import { ArrowDown, ArrowRight, Bot } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { SITE } from "@/lib/site";
+import { openAssistant } from "@/lib/site";
 import { useI18n } from "@/components/i18n-provider";
+import { type Lang } from "@/lib/i18n";
 import { track } from "@/lib/analytics";
+
+const COPY: Record<Lang, {
+  eyebrow: string;
+  titleA: string;
+  titleB: string;
+  desc: string;
+  primary: string;
+  work: string;
+  hint: string;
+}> = {
+  en: {
+    eyebrow: "GROWTH SYSTEMS · DIGITAL PRODUCTS · PERSONAL BRAND",
+    titleA: "More qualified attention. More enquiries. ",
+    titleB: "Less manual work.",
+    desc: "If demand is too low, leads are leaking or too much depends on someone remembering the next step, we start with that bottleneck and build the system around it.",
+    primary: "Find the bottleneck",
+    work: "See real work",
+    hint: "Start with the business problem",
+  },
+  ua: {
+    eyebrow: "GROWTH SYSTEMS · DIGITAL PRODUCTS · PERSONAL BRAND",
+    titleA: "Більше якісної уваги. Більше звернень. ",
+    titleB: "Менше ручної роботи.",
+    desc: "Якщо попиту замало, заявки губляться або занадто багато тримається на тому, що хтось має вчасно згадати про наступний крок, починаємо саме з цього вузького місця й будуємо систему навколо нього.",
+    primary: "Знайти вузьке місце",
+    work: "Подивитися реальні роботи",
+    hint: "Почніть з бізнес-проблеми",
+  },
+  ru: {
+    eyebrow: "GROWTH SYSTEMS · DIGITAL PRODUCTS · PERSONAL BRAND",
+    titleA: "Больше качественного внимания. Больше заявок. ",
+    titleB: "Меньше ручной работы.",
+    desc: "Если спроса мало, заявки теряются или слишком многое держится на том, что кто-то должен вовремя вспомнить о следующем шаге, начинаем именно с этого узкого места и строим систему вокруг него.",
+    primary: "Найти узкое место",
+    work: "Посмотреть реальные работы",
+    hint: "Начните с бизнес-проблемы",
+  },
+};
 
 const scrollTo = (id: string) => {
   if (typeof document === "undefined") return;
@@ -14,112 +52,60 @@ const scrollTo = (id: string) => {
 };
 
 export function Hero() {
-  const { t } = useI18n();
+  const { lang, t } = useI18n();
+  const x = COPY[lang];
+
   return (
-    <section
-      id="top"
-      className="relative min-h-screen py-0 flex items-center justify-center overflow-hidden bg-black"
-    >
-      {/* Premium black/gold backdrop */}
-      <div className="absolute inset-0 z-0">
-        <div
-          className="absolute top-[18%] left-1/2 -translate-x-1/2 w-[90%] h-[55%] blur-[120px]"
-          style={{
-            background:
-              "radial-gradient(closest-side, rgba(212,175,55,0.16), rgba(184,134,11,0.05), transparent 75%)",
-          }}
-        />
-        <div
-          className="absolute inset-0 opacity-[0.04]"
-          style={{
-            backgroundImage:
-              "linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px)",
-            backgroundSize: "64px 64px",
-          }}
-        />
-        {/* vignette */}
-        <div
-          className="absolute inset-0"
-          style={{ background: "radial-gradient(120% 80% at 50% 30%, transparent 40%, rgba(0,0,0,0.85))" }}
-        />
+    <section id="top" className="relative flex min-h-screen items-center justify-center overflow-hidden bg-black py-0">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute left-[-18%] top-[12%] h-[620px] w-[620px] rounded-full bg-amber-300/[.09] blur-[150px]" />
+        <div className="absolute right-[-16%] top-[20%] h-[560px] w-[560px] rounded-full bg-sky-400/[.07] blur-[155px]" />
+        <div className="absolute left-1/2 top-[56%] h-px w-[82%] -translate-x-1/2 bg-gradient-to-r from-transparent via-amber-200/25 to-transparent" />
+        <div className="absolute inset-0 opacity-[.035]" style={{ backgroundImage: "linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px)", backgroundSize: "72px 72px", maskImage: "linear-gradient(to bottom, black, transparent 82%)" }} />
+        <div className="absolute inset-0 bg-[radial-gradient(100%_78%_at_50%_26%,transparent_30%,rgba(0,0,0,.88))]" />
       </div>
 
-      <div className="relative z-10 container mx-auto px-6 flex flex-col items-center text-center pt-28">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8 }}
-          className="space-y-8 w-full flex flex-col items-center"
-        >
-          {/* SEO heading (visual identity is the logo) */}
-          <h1 className="sr-only">
-            Vlad Kuzmenko — {t.hero.pillars.join(" · ")}. {t.hero.tagline}
-          </h1>
+      <div className="container relative z-10 mx-auto flex flex-col items-center px-5 pb-14 pt-28 text-center sm:px-6">
+        <motion.div initial={{ opacity: 0, y: 18 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.7 }} className="flex w-full max-w-6xl flex-col items-center">
+          <h1 className="sr-only">Vlad Kuzmenko — {x.titleA}{x.titleB}</h1>
 
-          {/* Brand wordmark */}
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="/brand/vlad-kuzmenko-logo-gold.png"
-            alt="Vlad Kuzmenko"
-            className="w-[280px] sm:w-[360px] md:w-[440px] h-auto select-none drop-shadow-[0_10px_40px_rgba(212,175,55,0.18)]"
-          />
+          <img src="/brand/vlad-kuzmenko-logo-gold.png" alt="Vlad Kuzmenko" className="h-auto w-[245px] select-none drop-shadow-[0_12px_42px_rgba(212,175,55,.18)] sm:w-[310px] md:w-[350px]" />
 
-          {/* Pillars */}
-          <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-xs sm:text-sm uppercase tracking-[0.2em] text-gray-300">
-            {t.hero.pillars.map((p, i) => (
-              <React.Fragment key={p}>
-                {i > 0 && <span className="pillar-dot">·</span>}
-                <span>{p}</span>
-              </React.Fragment>
-            ))}
-          </div>
+          <p className="mt-7 text-[10px] font-bold uppercase tracking-[.22em] text-zinc-500 sm:text-[11px]">{x.eyebrow}</p>
+          <div className="mt-6 h-px w-28 bg-gradient-to-r from-transparent via-amber-300/60 to-transparent" />
 
-          <div className="mx-auto h-px w-40 bg-gradient-to-r from-transparent via-amber-400/50 to-transparent" />
-
-          {/* Tagline */}
-          <p className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-white max-w-3xl">
-            {t.hero.tagline}
+          <p className="mt-7 max-w-5xl text-4xl font-black leading-[1.02] tracking-[-.045em] text-white sm:text-6xl lg:text-7xl">
+            {x.titleA}<span className="gradient-gold-text">{x.titleB}</span>
           </p>
+          <p className="mt-7 max-w-3xl text-base leading-7 text-zinc-300 sm:text-lg sm:leading-8">{x.desc}</p>
 
-          {/* Supporting */}
-          <p className="text-base md:text-lg text-gray-400 max-w-2xl leading-relaxed">
-            {t.hero.supporting}
-          </p>
-
-          {/* CTAs */}
-          <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center pt-2">
-            <a
-              href={SITE.calcom}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => track("calcom_click", { source: "hero" })}
-            >
-              <Button size="lg" className="premium-button min-w-[190px] h-12 text-base">
-                <Calendar className="mr-2 h-5 w-5" />
-                {t.cta.bookCall}
-              </Button>
-            </a>
-            <Button
-              size="lg"
-              variant="outline"
-              onClick={() => {
-                track("hero_view_work");
-                scrollTo("selected-work");
-              }}
-              className="min-w-[190px] h-12 text-base border-amber-400/30 bg-amber-400/[0.03] text-amber-100 hover:bg-amber-400/10"
-            >
-              {t.cta.viewWork}
+          <div className="mt-9 flex w-full flex-col items-center justify-center gap-3 sm:w-auto sm:flex-row sm:flex-wrap">
+            <Button size="lg" onClick={() => { track("hero_find_bottleneck"); scrollTo("growth-systems"); }} className="premium-button h-auto min-h-12 w-full px-7 py-3 text-base sm:w-auto">
+              {x.primary}<ArrowRight className="ml-2 h-4 w-4" />
             </Button>
+            <Button size="lg" variant="outline" onClick={() => { track("hero_view_work"); scrollTo("selected-work"); }} className="h-auto min-h-12 w-full border-white/15 bg-white/[.025] px-7 py-3 text-base text-white hover:border-white/25 hover:bg-white/[.055] sm:w-auto">
+              {x.work}
+            </Button>
+            <button type="button" onClick={() => { track("hero_open_assistant"); openAssistant(); }} className="inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-xl border border-sky-300/15 bg-sky-300/[.04] px-5 text-sm font-semibold text-sky-100/80 transition hover:border-sky-300/30 hover:bg-sky-300/[.08] sm:w-auto">
+              <Bot className="h-4 w-4" />{t.cta.askAI}
+            </button>
           </div>
 
-          <button
-            type="button"
-            onClick={() => scrollTo("ecosystem")}
-            className="mt-4 inline-flex flex-col items-center gap-2 text-gray-600 hover:text-amber-300 transition-colors"
-            aria-label={t.hero.viewWork}
-          >
-            <ArrowDown className="h-4 w-4 animate-bounce" />
-          </button>
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-3 text-[11px] text-zinc-500">
+            <span className="rounded-full border border-amber-300/[.12] bg-amber-300/[.025] px-3 py-1.5">Traffic</span>
+            <span className="h-1 w-1 rounded-full bg-zinc-700" />
+            <span className="rounded-full border border-sky-300/[.12] bg-sky-300/[.025] px-3 py-1.5">Conversion</span>
+            <span className="h-1 w-1 rounded-full bg-zinc-700" />
+            <span className="rounded-full border border-violet-300/[.12] bg-violet-300/[.025] px-3 py-1.5">Automation</span>
+          </div>
+
+          <div className="mt-12 flex items-center gap-3">
+            <span className="text-[10px] font-semibold uppercase tracking-[.18em] text-zinc-600">{x.hint}</span>
+            <button type="button" onClick={() => scrollTo("growth-systems")} className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/[.08] text-zinc-500 transition hover:border-amber-300/25 hover:text-amber-300" aria-label={x.primary}>
+              <ArrowDown className="h-4 w-4 animate-bounce" />
+            </button>
+          </div>
         </motion.div>
       </div>
     </section>

--- a/components/home/HomeContent.tsx
+++ b/components/home/HomeContent.tsx
@@ -1,6 +1,5 @@
 import { Header } from "@/components/ui/header";
 import { Hero } from "@/components/home/Hero";
-import { EcosystemNavigator } from "@/components/home/EcosystemNavigator";
 import { GrowthSystems } from "@/components/home/GrowthSystems";
 import { SelectedWork } from "@/components/home/SelectedWork";
 import { ProductsOverview } from "@/components/home/ProductsOverview";
@@ -12,17 +11,15 @@ import { ContactSection } from "@/components/home/ContactSection";
 import { FooterSection } from "@/components/FooterSection";
 
 /**
- * Shared homepage composition rendered by each language route.
- *
- * Order follows the ecosystem model: the umbrella first, then the four
- * directions in commercial priority, then the personal layer and contact.
+ * Homepage is refined section by section. The top now goes directly from the
+ * visitor-facing hero into the business problem / Growth Systems section.
+ * Lower sections remain untouched until their own review pass.
  */
 export function HomeContent() {
   return (
     <>
       <Header />
       <Hero />
-      <EcosystemNavigator />
       <GrowthSystems />
       <SelectedWork />
       <ProductsOverview />

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -2,13 +2,12 @@
 
 import React, { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
-import { Menu, X, Calendar } from "lucide-react";
+import { Bot, Calendar, Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { SITE } from "@/lib/site";
+import { SITE, openAssistant } from "@/lib/site";
 import { useI18n } from "@/components/i18n-provider";
-import { LANGS, LANG_LABELS, langHref } from "@/lib/i18n";
+import { LANGS, LANG_LABELS, langHref, type Lang } from "@/lib/i18n";
 
-// Sub-pages that exist in all three languages (for the language switcher).
 const LOCALIZED_SLUGS = new Set([
   "",
   "growth-systems",
@@ -21,24 +20,36 @@ const LOCALIZED_SLUGS = new Set([
   "warriors-team",
 ]);
 
+const NAV_COPY: Record<Lang, {
+  business: string;
+  work: string;
+  visibility: string;
+  warriors: string;
+  performance: string;
+  about: string;
+}> = {
+  en: { business: "For business", work: "Work", visibility: "VisibilityOS", warriors: "Warriors", performance: "Performance", about: "About" },
+  ua: { business: "Для бізнесу", work: "Роботи", visibility: "VisibilityOS", warriors: "Warriors", performance: "Performance", about: "Про мене" },
+  ru: { business: "Для бизнеса", work: "Работы", visibility: "VisibilityOS", warriors: "Warriors", performance: "Performance", about: "Обо мне" },
+};
+
 export function Header() {
   const { lang, t } = useI18n();
   const pathname = usePathname() || "/";
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const labels = NAV_COPY[lang];
 
-  const base = langHref(lang); // "/" | "/ua" | "/ru"
-  // Locale-aware absolute hash links: /#work, /ua#work, /ru#work
+  const base = langHref(lang);
   const hashHref = (id: string) => `${base === "/" ? "/" : base}#${id}`;
   const pageHref = (slug: string) => (base === "/" ? `/${slug}` : `${base}/${slug}`);
 
   const navItems: { title: string; href: string; hash?: string }[] = [
-    { title: t.nav.home, href: base },
-    { title: t.nav.services, href: pageHref("growth-systems") },
-    { title: t.nav.work, href: pageHref("work") },
-    { title: t.nav.products, href: pageHref("products") },
-    { title: t.nav.warriors, href: pageHref("warriors-team") },
-    { title: t.nav.drop, href: pageHref("drop") },
-    { title: t.nav.about, href: hashHref("about"), hash: "about" },
+    { title: labels.business, href: hashHref("growth-systems"), hash: "growth-systems" },
+    { title: labels.work, href: pageHref("work") },
+    { title: labels.visibility, href: pageHref("visibilityos") },
+    { title: labels.warriors, href: pageHref("warriors-team") },
+    { title: labels.performance, href: pageHref("drop") },
+    { title: labels.about, href: hashHref("about"), hash: "about" },
   ];
 
   const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>, item: { hash?: string }) => {
@@ -51,13 +62,11 @@ export function Header() {
     }
   };
 
-  // Path-aware language switch: keep the same localized sub-page when possible.
   const stripped = pathname.match(/^\/(ua|ru)(\/.*)?$/);
   const rel = stripped ? stripped[2] || "/" : pathname;
   const slug = rel === "/" ? "" : rel.replace(/^\//, "").split("/")[0];
   const switchHref = (l: (typeof LANGS)[number]) => {
     const b = l === "en" ? "" : `/${l}`;
-    // Detail routes like /work/<slug>: preserve the full sub-path across locales.
     if (slug === "work") return `${b}${rel}` || "/";
     const useSlug = LOCALIZED_SLUGS.has(slug) ? slug : "";
     return useSlug ? `${b}/${useSlug}` : b || "/";
@@ -80,15 +89,9 @@ export function Header() {
             href={switchHref(l)}
             aria-current={l === lang ? "true" : undefined}
             onClick={() => {
-              try {
-                localStorage.setItem("vk_lang", l);
-              } catch {
-                /* no-op */
-              }
+              try { localStorage.setItem("vk_lang", l); } catch { /* no-op */ }
             }}
-            className={`px-1.5 py-1 rounded transition-colors ${
-              l === lang ? "text-amber-300" : "text-gray-500 hover:text-amber-200"
-            }`}
+            className={`rounded px-1.5 py-1 transition-colors ${l === lang ? "text-amber-300" : "text-zinc-500 hover:text-zinc-200"}`}
           >
             {LANG_LABELS[l]}
           </a>
@@ -98,78 +101,60 @@ export function Header() {
   );
 
   return (
-    <header className="w-full z-30 fixed top-0 left-0 bg-black/70 backdrop-blur-xl border-b border-amber-400/10">
-      <div className="container relative mx-auto h-[80px] flex items-center justify-between gap-4">
-        {/* Logo */}
-        <a href={base} className="flex items-center shrink-0" aria-label="Vlad Kuzmenko — Home">
+    <header className="fixed left-0 top-0 z-30 w-full border-b border-white/[.07] bg-black/70 backdrop-blur-2xl">
+      <div className="container relative mx-auto flex h-[78px] items-center justify-between gap-4 px-4 sm:px-6">
+        <a href={base} className="flex shrink-0 items-center" aria-label="Vlad Kuzmenko — Home">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="/brand/vlad-kuzmenko-logo-gold.png"
-            alt="Vlad Kuzmenko"
-            className="h-11 sm:h-12 w-auto select-none"
-          />
+          <img src="/brand/vlad-kuzmenko-logo-gold.png" alt="Vlad Kuzmenko" className="h-10 w-auto select-none sm:h-11" />
         </a>
 
-        {/* Desktop nav — kept on a single row at every desktop width, so the
-            labels stay legible instead of wrapping under each other. */}
-        <nav className="hidden xl:flex items-center gap-1">
+        <nav className="hidden items-center gap-0.5 xl:flex">
           {navItems.map((item) => (
-            <a
-              key={item.title}
-              href={item.href}
-              onClick={(e) => handleNavClick(e, item)}
-              className="whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium text-gray-300 transition-colors hover:bg-white/5 hover:text-amber-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/60"
-            >
+            <a key={item.title} href={item.href} onClick={(e) => handleNavClick(e, item)} className="whitespace-nowrap rounded-lg px-3 py-2 text-[13px] font-medium text-zinc-300 transition-colors hover:bg-white/[.045] hover:text-white">
               {item.title}
             </a>
           ))}
         </nav>
 
-        {/* Right CTAs */}
-        <div className="hidden md:flex items-center gap-2 shrink-0 xl:gap-3">
+        <div className="hidden shrink-0 items-center gap-2 md:flex">
           <LangSwitcher />
+          <button type="button" onClick={openAssistant} className="hidden h-10 items-center gap-2 rounded-xl border border-sky-300/15 bg-sky-300/[.045] px-3.5 text-sm font-semibold text-sky-100/80 transition hover:border-sky-300/30 hover:bg-sky-300/[.08] xl:inline-flex">
+            <Bot className="h-4 w-4" />
+            {t.cta.askAI}
+          </button>
           <a href={SITE.calcom} target="_blank" rel="noopener noreferrer">
-            <Button className="premium-button h-10 px-5">
+            <Button className="premium-button h-10 px-4 xl:px-5">
               <Calendar className="mr-2 h-4 w-4" />
               {t.cta.bookCall}
             </Button>
           </a>
         </div>
 
-        {/* Menu toggle — carries the full nav below the desktop breakpoint */}
-        <div className="flex xl:hidden items-center gap-2">
+        <div className="flex items-center gap-2 xl:hidden">
           <LangSwitcher className="md:hidden" />
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => setMobileMenuOpen((o) => !o)}
-            aria-label="Toggle menu"
-          >
-            {isMobileMenuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+          <Button variant="ghost" size="icon" onClick={() => setMobileMenuOpen((open) => !open)} aria-label="Toggle menu" aria-expanded={isMobileMenuOpen}>
+            {isMobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
           </Button>
         </div>
       </div>
 
-      {/* Mobile menu */}
       {isMobileMenuOpen && (
-        <div className="absolute top-full left-0 right-0 border-t border-amber-400/10 bg-black/95 backdrop-blur-xl shadow-2xl px-4 pt-2 pb-5 flex flex-col gap-1 xl:hidden">
-          {navItems.map((item) => (
-            <a
-              key={item.title}
-              href={item.href}
-              onClick={(e) => handleNavClick(e, item)}
-              className="rounded-md py-2.5 px-2 text-base font-medium text-gray-200 hover:text-amber-200 border-b border-border/20 last:border-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/60"
-            >
-              {item.title}
-            </a>
-          ))}
-          <div className="pt-3 flex flex-col gap-2">
-            <a href={SITE.calcom} target="_blank" rel="noopener noreferrer">
-              <Button className="w-full premium-button">
-                <Calendar className="mr-2 h-4 w-4" />
-                {t.cta.bookCall}
-              </Button>
-            </a>
+        <div className="absolute left-0 right-0 top-full border-t border-white/[.07] bg-[#050505]/98 px-4 pb-5 pt-2 shadow-2xl backdrop-blur-2xl xl:hidden">
+          <div className="container mx-auto flex flex-col gap-1 px-0">
+            {navItems.map((item) => (
+              <a key={item.title} href={item.href} onClick={(e) => handleNavClick(e, item)} className="rounded-xl border-b border-white/[.05] px-3 py-3 text-base font-medium text-zinc-200 last:border-0 hover:bg-white/[.04] hover:text-white">
+                {item.title}
+              </a>
+            ))}
+            <div className="mt-2 grid gap-2 border-t border-white/[.07] pt-4 sm:grid-cols-2">
+              <button type="button" onClick={() => { setMobileMenuOpen(false); openAssistant(); }} className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-sky-300/15 bg-sky-300/[.045] px-4 text-sm font-semibold text-sky-100/80">
+                <Bot className="h-4 w-4" />
+                {t.cta.askAI}
+              </button>
+              <a href={SITE.calcom} target="_blank" rel="noopener noreferrer">
+                <Button className="premium-button min-h-11 w-full"><Calendar className="mr-2 h-4 w-4" />{t.cta.bookCall}</Button>
+              </a>
+            </div>
           </div>
         </div>
       )}

--- a/components/voiceflow-script.tsx
+++ b/components/voiceflow-script.tsx
@@ -2,6 +2,7 @@
 
 import Script from "next/script";
 
+// Global assistant entry used by both the floating launcher and explicit Ask AI CTAs.
 export function VoiceflowScript() {
   return (
     <>

--- a/components/voiceflow-script.tsx
+++ b/components/voiceflow-script.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Script from "next/script";
+
+export function VoiceflowScript() {
+  return (
+    <>
+      <Script id="vf-clean" strategy="afterInteractive">
+        {`
+          try {
+            document.querySelectorAll('link[rel="preload"],link[rel="prefetch"]').forEach(function(l){
+              var href = (l.getAttribute('href') || '');
+              if (href.includes('voiceflow.com')) l.parentNode && l.parentNode.removeChild(l);
+            });
+            document.querySelectorAll('script').forEach(function(s){
+              var src = s.getAttribute('src') || '';
+              if (src.includes('voiceflow.com') && !/\\bvf-inline\\b/.test(s.id || '')) {
+                s.parentNode && s.parentNode.removeChild(s);
+              }
+            });
+            try { delete window.__vf_loaded; } catch(_) {}
+            try { delete window.voiceflow; } catch(_) {}
+          } catch(e) { /* no-op */ }
+        `}
+      </Script>
+
+      <Script id="vf-inline" strategy="afterInteractive">
+        {`
+          (function(d, t) {
+            if (window.__vf_loaded) return;
+            window.__vf_loaded = true;
+
+            var v = d.createElement(t), s = d.getElementsByTagName(t)[0];
+            v.onload = function() {
+              try {
+                window.voiceflow && window.voiceflow.chat && window.voiceflow.chat.load({
+                  verify: { projectID: '68d68da7396d9a683e17de9a' },
+                  url: 'https://general-runtime.voiceflow.com',
+                  versionID: 'production',
+                  voice: { url: 'https://runtime-api.voiceflow.com' },
+                  allowIframe: true,
+                  assistant: {
+                    title: 'Vlad Kuzmenko — AI Assistant',
+                    description: 'Ask about growth systems, websites, products or working with Vlad.',
+                    overlays: { branding: { visible: false } }
+                  }
+                });
+
+                var css = d.createElement('style');
+                css.innerHTML = ".vfrc-launcher,.vfrc-widget{z-index:2147483647!important}.vfrc-launcher{right:24px!important;bottom:96px!important}";
+                d.head.appendChild(css);
+              } catch(e){ console.warn('Voiceflow load failed', e); }
+            };
+            v.src = "https://cdn.voiceflow.com/widget-next/bundle.mjs";
+            v.type = "text/javascript";
+            s.parentNode.insertBefore(v, s);
+          })(document, 'script');
+        `}
+      </Script>
+    </>
+  );
+}

--- a/docs/HOMEPAGE_SECTION_REVIEW.md
+++ b/docs/HOMEPAGE_SECTION_REVIEW.md
@@ -1,0 +1,12 @@
+# Homepage section-by-section review
+
+Current pass is intentionally limited to:
+
+1. Header / navigation
+2. Hero
+3. Client Growth Systems
+4. Restored AI assistant entry and widget
+
+The previous four-direction Ecosystem Navigator is not part of the homepage top.
+
+Everything below Selected Work remains for a later dedicated review pass. Do not merge this branch until the homepage is visually approved on desktop and mobile and the final build is verified.

--- a/docs/PREVIEW_REDEPLOY_TRIGGER_2026-08-15.txt
+++ b/docs/PREVIEW_REDEPLOY_TRIGGER_2026-08-15.txt
@@ -1,0 +1,1 @@
+Preview redeploy trigger after restoring components/voiceflow-script.tsx. No production behavior changes in this file.

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -3,10 +3,6 @@
 // with a clean, consistent payload (intent + contact fields + page/UTM context).
 // Cal.com is used only for "Book a call" buttons — never for website forms.
 
-// Webhook is read from an env var so it isn't hardcoded across the app.
-// It is a public ingestion endpoint (not a secret); the fallback keeps the site
-// working if the env var is not set. To override, set NEXT_PUBLIC_LEAD_WEBHOOK_URL
-// in the host (see README / PR notes).
 const WEBHOOK_URL =
   process.env.NEXT_PUBLIC_LEAD_WEBHOOK_URL ||
   "https://n8n.vladkuzmenkoai.com/webhook/b60f2736-ecb9-451a-b38e-5018c3935013";
@@ -16,7 +12,6 @@ export const SITE = {
   domain: "vladkuzmenko.com",
   url: "https://vladkuzmenko.com",
   email: "ai@vladkuzmenko.com",
-  // Real Cal.com booking link (booking only — not used for website forms)
   calcom: "https://cal.com/vladkuzmenko.com/call",
   webhook: WEBHOOK_URL,
   socials: {
@@ -29,39 +24,25 @@ export const SITE = {
   },
 } as const;
 
-/** Pull any UTM parameters from the current URL (campaign attribution). */
 function collectUtm(): Record<string, string> {
   if (typeof window === "undefined") return {};
   const out: Record<string, string> = {};
   try {
     const p = new URLSearchParams(window.location.search);
-    ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"].forEach(
-      (k) => {
-        const v = p.get(k);
-        if (v) out[k] = v;
-      }
-    );
+    ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"].forEach((k) => {
+      const v = p.get(k);
+      if (v) out[k] = v;
+    });
   } catch {
     /* no-op */
   }
   return out;
 }
 
-/**
- * Submit a website lead to the n8n webhook.
- * Enriches every payload with a consistent envelope:
- *   source, sourcePage, referrer, submittedAt, utm_* (+ the caller's intent/fields).
- * Callers should always pass at least an `intent`. Returns true on a 2xx response.
- */
-export async function submitLead(
-  payload: Record<string, unknown>
-): Promise<boolean> {
+export async function submitLead(payload: Record<string, unknown>): Promise<boolean> {
   const enriched = {
     source: SITE.domain,
-    sourcePage:
-      typeof window !== "undefined"
-        ? window.location.pathname + window.location.hash
-        : "",
+    sourcePage: typeof window !== "undefined" ? window.location.pathname + window.location.hash : "",
     referrer: typeof document !== "undefined" ? document.referrer : "",
     submittedAt: new Date().toISOString(),
     ...collectUtm(),
@@ -78,5 +59,16 @@ export async function submitLead(
   } catch (err) {
     console.error("submitLead failed", err);
     return false;
+  }
+}
+
+/** Open the globally mounted Voiceflow assistant. */
+export function openAssistant(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const vf = (window as unknown as { voiceflow?: { chat?: { open?: () => void } } }).voiceflow;
+    vf?.chat?.open?.();
+  } catch {
+    /* no-op */
   }
 }


### PR DESCRIPTION
Clean iteration based on current main. This pass changes only the top of the homepage and restores the assistant without reviving the old cart.

Current review scope:
- header/navigation;
- hero;
- Client Growth Systems;
- Voiceflow assistant entry/widget restored.

The old four-direction Ecosystem Navigator is removed from the homepage top. Everything below Selected Work is intentionally left for later section-by-section review. Do not merge until the user approves the homepage sections and responsive QA is complete.