### PR TITLE
Harden VisibilityOS release and canonical SEO surface

### DIFF
--- a/.github/workflows/website-release-quality.yml
+++ b/.github/workflows/website-release-quality.yml
@@ -56,6 +56,7 @@ jobs:
             components/pages/VisibilityOsPage.tsx \
             components/pages/VisibilityOsPremiumPage.tsx \
             components/pages/VisibilityOsMarketPage.tsx \
+            components/pages/VisibilityOsIntentBridge.tsx \
             components/pages/WarriorsTeamPage.tsx \
             components/pages/DropPage.tsx \
             lib/directions.ts \

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
-import { SITE } from "@/lib/site";
+
+const PRODUCTION_ORIGIN = "https://www.vladkuzmenko.com";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -8,7 +9,7 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: ["/api/"],
     },
-    sitemap: `${SITE.url}/sitemap.xml`,
-    host: SITE.url,
+    sitemap: `${PRODUCTION_ORIGIN}/sitemap.xml`,
+    host: PRODUCTION_ORIGIN,
   };
 }

--- a/app/robots.txt
+++ b/app/robots.txt
@@ -1,5 +1,0 @@
-User-agent: *
-Allow: /
-
-# Sitemaps
-Sitemap: https://vladkuzmenko.com/sitemap.xml

--- a/app/ru/visibilityos/page.tsx
+++ b/app/ru/visibilityos/page.tsx
@@ -1,4 +1,5 @@
 import { I18nProvider } from "@/components/i18n-provider";
+import { VisibilityOsIntentBridge } from "@/components/pages/VisibilityOsIntentBridge";
 import { VisibilityOsMarketPage } from "@/components/pages/VisibilityOsMarketPage";
 import { pageMeta } from "@/lib/page-meta";
 
@@ -12,6 +13,7 @@ export const metadata = pageMeta(
 export default function Page() {
   return (
     <I18nProvider lang="ru">
+      <VisibilityOsIntentBridge />
       <VisibilityOsMarketPage />
     </I18nProvider>
   );

--- a/app/ua/visibilityos/page.tsx
+++ b/app/ua/visibilityos/page.tsx
@@ -1,4 +1,5 @@
 import { I18nProvider } from "@/components/i18n-provider";
+import { VisibilityOsIntentBridge } from "@/components/pages/VisibilityOsIntentBridge";
 import { VisibilityOsMarketPage } from "@/components/pages/VisibilityOsMarketPage";
 import { pageMeta } from "@/lib/page-meta";
 
@@ -12,6 +13,7 @@ export const metadata = pageMeta(
 export default function Page() {
   return (
     <I18nProvider lang="ua">
+      <VisibilityOsIntentBridge />
       <VisibilityOsMarketPage />
     </I18nProvider>
   );

--- a/app/visibilityos/page.tsx
+++ b/app/visibilityos/page.tsx
@@ -1,4 +1,5 @@
 import { I18nProvider } from "@/components/i18n-provider";
+import { VisibilityOsIntentBridge } from "@/components/pages/VisibilityOsIntentBridge";
 import { VisibilityOsMarketPage } from "@/components/pages/VisibilityOsMarketPage";
 import { pageMeta } from "@/lib/page-meta";
 
@@ -12,6 +13,7 @@ export const metadata = pageMeta(
 export default function Page() {
   return (
     <I18nProvider lang="en">
+      <VisibilityOsIntentBridge />
       <VisibilityOsMarketPage />
     </I18nProvider>
   );

--- a/app/visibilityos/page.tsx
+++ b/app/visibilityos/page.tsx
@@ -6,7 +6,7 @@ export const metadata = pageMeta(
   "en",
   "visibilityos",
   "VisibilityOS — Website, Local SEO & Conversion Visibility Map",
-  "Scan a public website in its real service and location context. Map crawl, SEO, local relevance, trust and conversion signals, compare competitors and get a prioritized Growth Queue."
+  "Scan a website in its real service and location context. Map crawl, SEO, local relevance, trust and conversion gaps, compare competitors and get a Growth Queue."
 );
 
 export default function Page() {

--- a/components/pages/VisibilityOsIntentBridge.tsx
+++ b/components/pages/VisibilityOsIntentBridge.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * The product cards are visible before a user runs a scan, while the contextual
+ * request form intentionally renders only after a real scan exists. This small
+ * bridge preserves the same CTA semantics: before results it moves the visitor
+ * to the scan input; after results the page's native handlers take over and
+ * move to the contextual request form.
+ */
+export function VisibilityOsIntentBridge() {
+  useEffect(() => {
+    const product = document.getElementById("product");
+    if (!product) return;
+
+    const handleIntent = (event: Event) => {
+      if (document.getElementById("request-plan")) return;
+
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      const button = target.closest("button[type='button']");
+      if (!button || !product.contains(button)) return;
+
+      const scan = document.getElementById("scan");
+      if (!scan) return;
+
+      scan.scrollIntoView({ behavior: "smooth", block: "start" });
+      window.setTimeout(() => {
+        document.getElementById("visibility-url")?.focus({ preventScroll: true });
+      }, 450);
+    };
+
+    product.addEventListener("click", handleIntent, true);
+    return () => product.removeEventListener("click", handleIntent, true);
+  }, []);
+
+  return null;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,19 @@ const nextConfig = {
     loader: 'custom',
     loaderFile: './image-loader.js'
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+        ],
+      },
+    ];
+  },
   webpack: (config) => {
     config.resolve.fallback = {
       ...config.resolve.fallback,


### PR DESCRIPTION
## Release hardening
- removes the legacy static `app/robots.txt` that was shadowing the canonical metadata route
- pins `robots.txt` to the `www.vladkuzmenko.com` production origin and disallows `/api/`
- adds safe response headers: nosniff, strict-origin referrer policy, SAMEORIGIN framing and restrictive permissions policy
- shortens the EN VisibilityOS meta description into the scanner's own useful range
- fixes pre-result Growth Plan / Monitoring Beta CTAs so they route visitors into the scan instead of becoming no-ops
- extends the release lint surface to cover the CTA bridge

## Why
Production self-audit caught two real release-quality issues after V2: the legacy static robots file was still winning over `app/robots.ts`, and the security header set was thinner than intended. The product should pass its own high-confidence checks before market promotion.

## Required verification
- PR CI green
- exact-head Vercel preview READY
- preview `robots.txt` contains canonical www sitemap + `/api/` disallow
- preview VisibilityOS EN/UA/RU render and metadata remain correct
- after squash merge, verify the exact production commit/deployment/domain
- re-run production self-scan and SSRF regression